### PR TITLE
Add board name customization and LED status

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,30 +11,33 @@
 [env]
 monitor_speed = 420000
 
-[release]
-build_flags =
-   -DUSE_TINYUSB
-
-[debug]
-build_flags =
-   -DUSE_TINYUSB
-   -DDEBUG
-
-[xiao-samd21]
+[xiao_samd21]
 platform = atmelsam@8.1.0
 platform_packages = platformio/framework-arduino-samd-seeed@1.8.1
 board = seeed_xiao
 framework = arduino
 lib_deps = https://github.com/adafruit/Adafruit_TinyUSB_Arduino.git#0.10.5
 lib_archive = no
+build_flags =
+  -DUSE_TINYUSB
+  -DCRSF_SERIAL=Serial1
+  -DLED_PIN=13
+  -DLED_ON=0
+  -DLED_OFF=1
 
-[xiao-rp2040]
+[xiao_rp2040]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 framework = arduino
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m
 board = seeed_xiao_rp2040
 lib_deps = adafruit/Adafruit TinyUSB Library@^3.7.3
+build_flags =
+  -DUSE_TINYUSB
+  -DCRSF_SERIAL=Serial1
+  -DLED_PIN=17
+  -DLED_ON=0
+  -DLED_OFF=1
 
 [pico]
 platform = https://github.com/maxgerhardt/platform-raspberrypi
@@ -43,21 +46,36 @@ board_build.core = earlephilhower
 framework = arduino
 board_build.filesystem = littlefs
 lib_deps = adafruit/Adafruit TinyUSB Library@^3.7.3
+build_flags =
+  -DUSE_TINYUSB
+  -DCRSF_SERIAL=Serial2
+  -DLED_PIN=25
+  -DLED_ON=1
+  -DLED_OFF=0
 
 [env:XIAO_SAMD21]
-extends = xiao-samd21, release
+extends = xiao_samd21
 
 [env:XIAO_SAMD21_Debug]
-extends = xiao-samd21, debug
+extends = xiao_samd21
+build_flags =
+  ${xiao_samd21.build_flags}
+  -DDEBUG
 
 [env:XIAO_RP2040]
-extends=xiao-rp2040, release
+extends = xiao_rp2040
 
 [env:XIAO_RP2040_Debug]
-extends=xiao-rp2040, debug
+extends = xiao_rp2040
+build_flags =
+  ${xiao_rp2040.build_flags}
+  -DDEBUG
 
 [env:PICO]
-extends=pico, release
+extends = pico
 
 [env:PICO_Debug]
-extends=pico, debug
+extends = pico
+build_flags =
+  ${pico.build_flags}
+  -DDEBUG

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,15 @@
 #include <Arduino.h>
 #include <Adafruit_TinyUSB.h> 
 
+// Board name
+#define MANUFACTURER_NAME "USB_ELRS_Receiver"
+#define PRODUCT_NAME     "USB_ELRS_Receiver"
+
+// CrossFire settings
+#define CRSF_BAUDRATE 420000
+#define CRSF_MAX_PACKET_LEN 64
+#define CRSF_NUM_CHANNELS 16
+
 // USB HID report descriptor
 // Specifies the structure of the gamepad data (for radio receiver 
 // (16bit data x 8ch) + (1bit data x 8ch))
@@ -22,11 +31,6 @@
       HID_REPORT_COUNT(8), HID_REPORT_SIZE(1),                                \
       HID_INPUT(HID_DATA | HID_VARIABLE | HID_ABSOLUTE),                      \
       HID_COLLECTION_END  
-
-// CrossFire settings
-#define CRSF_BAUDRATE 420000
-#define CRSF_MAX_PACKET_LEN 64
-#define CRSF_NUM_CHANNELS 16
 
 typedef enum {
   CRSF_ADDRESS_BROADCAST = 0x00,
@@ -108,6 +112,11 @@ void uart();
 
 void setup()
 {
+  // Custom board name
+  USBDevice.setManufacturerDescriptor(MANUFACTURER_NAME);
+  USBDevice.setProductDescriptor(PRODUCT_NAME);
+  USBDevice.setID(0x1209, 0x0408); // 0x1209 is common ID for opensource projects, 0x0408 is generated randomly
+
   // USB HID Device Settings
   usb_hid.setPollInterval(2);
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,14 @@
 #define CRSF_MAX_PACKET_LEN 64
 #define CRSF_NUM_CHANNELS 16
 
+// LED connection status variables
+uint32_t lastDataAvailable = 0;  // Last time CRSF_SERIAL.available() was true
+uint32_t lastLedToggle = 0;      // Last time LED was toggled
+bool ledState = LOW;             // Current LED state
+
+#define LED_BLINK_INTERVAL 500    // LED blink interval when disconnected (ms)
+#define CONNECTION_TIMEOUT 60000  // Time to wait before turning off LED completely (ms)
+
 // USB HID report descriptor
 // Specifies the structure of the gamepad data (for radio receiver 
 // (16bit data x 8ch) + (1bit data x 8ch))
@@ -85,8 +93,10 @@ uint8_t const desc_hid_report[] = {
 // Define CRSF serial port based on board type
 #ifdef ARDUINO_RASPBERRY_PI_PICO
   #define CRSF_SERIAL Serial2
+  #define LED_PIN 25
 #else
   #define CRSF_SERIAL Serial1
+  #define LED_PIN 13
 #endif
 
 typedef struct __attribute__((packed)) gamepad_data {
@@ -109,6 +119,7 @@ void debug_out();
 void crsf();
 void crsfdecode();
 void uart();
+void updateLed();
 
 void setup()
 {
@@ -137,6 +148,10 @@ void setup()
 #endif
   CRSF_SERIAL.begin(CRSF_BAUDRATE, SERIAL_8N1);
 
+  // Initialize LED pin
+  pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, LOW);
+
 #if defined(DEBUG)
   time_m = micros();  // For interval measurement
 #endif
@@ -150,6 +165,7 @@ void loop()
   }
   crsf();           // Process CRSF
   uart();           // UART communication processing (for firmware rewriting)
+  updateLed();      // Update LED status
   if (datardyf) {   // USB transmission when data is ready
     if (usb_hid.ready()) {
       usb_hid.sendReport(0, &gp, sizeof(gp));
@@ -167,6 +183,7 @@ void crsf()
   uint8_t data;
   // byte received from CRSF
   if (CRSF_SERIAL.available()) {  // If there is incoming data on CRSF serial
+    lastDataAvailable = millis();  // Update last connection time
     data = CRSF_SERIAL.read();    // 8-bit data read
     gaptime = micros();
     if (rxPos == 1) {
@@ -264,3 +281,33 @@ void debug_out()
   time_m = micros();
 }
 #endif
+
+// LED status update function
+void updateLed()
+{
+  uint32_t currentTime = millis();
+  uint32_t timeSinceLastData = currentTime - lastDataAvailable;
+
+  // If we have recent CRSF data (within last 100ms), connection is active
+  if (timeSinceLastData < 100) {
+    // Connected - LED solid ON
+    digitalWrite(LED_PIN, HIGH);
+    ledState = HIGH;
+  } else if (timeSinceLastData < CONNECTION_TIMEOUT) { // If disconnected but within 60 seconds, blink LED
+    // Blink LED every 500ms
+    if (currentTime - lastLedToggle >= LED_BLINK_INTERVAL) {
+      ledState = !ledState;
+      digitalWrite(LED_PIN, ledState);
+      lastLedToggle = currentTime;
+    }
+  } else { // If disconnected for more than 60 seconds, turn LED OFF
+    digitalWrite(LED_PIN, LOW);
+    ledState = LOW;
+  }
+
+  // Initialize lastDataAvailable on first run
+  if (lastDataAvailable == 0) {
+    lastDataAvailable = currentTime;
+    lastLedToggle = currentTime;
+  }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include <Adafruit_TinyUSB.h> 
+#include <Adafruit_TinyUSB.h>
 
 // Board name
 #define MANUFACTURER_NAME "USB_ELRS_Receiver"
@@ -13,13 +13,12 @@
 // LED connection status variables
 uint32_t lastDataAvailable = 0;  // Last time CRSF_SERIAL.available() was true
 uint32_t lastLedToggle = 0;      // Last time LED was toggled
-bool ledState = LOW;             // Current LED state
 
 #define LED_BLINK_INTERVAL 500    // LED blink interval when disconnected (ms)
 #define CONNECTION_TIMEOUT 60000  // Time to wait before turning off LED completely (ms)
 
 // USB HID report descriptor
-// Specifies the structure of the gamepad data (for radio receiver 
+// Specifies the structure of the gamepad data (for radio receiver
 // (16bit data x 8ch) + (1bit data x 8ch))
 #define TUD_HID_REPORT_DESC_GAMEPAD_9(...)                                    \
   HID_USAGE_PAGE(HID_USAGE_PAGE_DESKTOP),                                     \
@@ -38,7 +37,7 @@ bool ledState = LOW;             // Current LED state
       HID_USAGE_MAX(8), HID_LOGICAL_MIN(0), HID_LOGICAL_MAX(1),               \
       HID_REPORT_COUNT(8), HID_REPORT_SIZE(1),                                \
       HID_INPUT(HID_DATA | HID_VARIABLE | HID_ABSOLUTE),                      \
-      HID_COLLECTION_END  
+      HID_COLLECTION_END
 
 typedef enum {
   CRSF_ADDRESS_BROADCAST = 0x00,
@@ -151,6 +150,8 @@ void setup()
   // Initialize LED pin
   pinMode(LED_PIN, OUTPUT);
   digitalWrite(LED_PIN, LOW);
+  lastDataAvailable = millis();
+  lastLedToggle = millis();
 
 #if defined(DEBUG)
   time_m = micros();  // For interval measurement
@@ -285,29 +286,23 @@ void debug_out()
 // LED status update function
 void updateLed()
 {
+  static bool ledState = LOW;
   uint32_t currentTime = millis();
   uint32_t timeSinceLastData = currentTime - lastDataAvailable;
 
   // If we have recent CRSF data (within last 100ms), connection is active
   if (timeSinceLastData < 100) {
     // Connected - LED solid ON
-    digitalWrite(LED_PIN, HIGH);
     ledState = HIGH;
-  } else if (timeSinceLastData < CONNECTION_TIMEOUT) { // If disconnected but within 60 seconds, blink LED
-    // Blink LED every 500ms
-    if (currentTime - lastLedToggle >= LED_BLINK_INTERVAL) {
-      ledState = !ledState;
-      digitalWrite(LED_PIN, ledState);
-      lastLedToggle = currentTime;
-    }
-  } else { // If disconnected for more than 60 seconds, turn LED OFF
-    digitalWrite(LED_PIN, LOW);
+  } else if (timeSinceLastData < CONNECTION_TIMEOUT) {
+    // Disconnected but within timeout - blink LED every 500ms
+    if (currentTime - lastLedToggle < LED_BLINK_INTERVAL) return;
+    lastLedToggle = currentTime;
+    ledState = !ledState;
+  } else {
+    // Disconnected for more than 60 seconds - turn LED OFF
     ledState = LOW;
   }
 
-  // Initialize lastDataAvailable on first run
-  if (lastDataAvailable == 0) {
-    lastDataAvailable = currentTime;
-    lastLedToggle = currentTime;
-  }
+  digitalWrite(LED_PIN, ledState);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,14 +89,6 @@ uint8_t const desc_hid_report[] = {
     TUD_HID_REPORT_DESC_GAMEPAD_9()  // USB GamePad data structure
 };
 
-// Define CRSF serial port based on board type
-#ifdef ARDUINO_RASPBERRY_PI_PICO
-  #define CRSF_SERIAL Serial2
-  #define LED_PIN 25
-#else
-  #define CRSF_SERIAL Serial1
-  #define LED_PIN 13
-#endif
 
 typedef struct __attribute__((packed)) gamepad_data {
   uint16_t ch[8];  // 16 bit 8ch
@@ -149,7 +141,7 @@ void setup()
 
   // Initialize LED pin
   pinMode(LED_PIN, OUTPUT);
-  digitalWrite(LED_PIN, LOW);
+  digitalWrite(LED_PIN, LED_OFF);
   lastDataAvailable = millis();
   lastLedToggle = millis();
 
@@ -286,14 +278,14 @@ void debug_out()
 // LED status update function
 void updateLed()
 {
-  static bool ledState = LOW;
+  static bool ledState = LED_OFF;
   uint32_t currentTime = millis();
   uint32_t timeSinceLastData = currentTime - lastDataAvailable;
 
   // If we have recent CRSF data (within last 100ms), connection is active
   if (timeSinceLastData < 100) {
     // Connected - LED solid ON
-    ledState = HIGH;
+    ledState = LED_ON;
   } else if (timeSinceLastData < CONNECTION_TIMEOUT) {
     // Disconnected but within timeout - blink LED every 500ms
     if (currentTime - lastLedToggle < LED_BLINK_INTERVAL) return;
@@ -301,7 +293,7 @@ void updateLed()
     ledState = !ledState;
   } else {
     // Disconnected for more than 60 seconds - turn LED OFF
-    ledState = LOW;
+    ledState = LED_OFF;
   }
 
   digitalWrite(LED_PIN, ledState);


### PR DESCRIPTION
1. Add board name customization
<img height="200" alt="image" src="https://github.com/user-attachments/assets/fdd9527b-730d-42f6-868e-a1ea9510ebc7" />

2. LED status to show the connectivity
	- Connected: Solid on
	- Disconnected: Blink for 60s and if still no connection then off